### PR TITLE
feat: 限制 log 日志压缩文件数量最大为 100

### DIFF
--- a/Sources/CocoaLumberjack/DDFileLogger.m
+++ b/Sources/CocoaLumberjack/DDFileLogger.m
@@ -160,7 +160,7 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
         if (maximumNumberOfLogZipFiles < 1) {
             _maximumNumberOfLogZipFiles = 1;
         } else {
-            _maximumNumberOfLogZipFiles = MIN(maximumNumberOfLogZipFiles, 5);
+            _maximumNumberOfLogZipFiles = MIN(maximumNumberOfLogZipFiles, 100);
         }
         NSLogInfo(@"DDFileLogManagerDefault: Responding to configuration change: maximumNumberOfLogZipFiles");
         [self deleteOldZipFilesForConfigurationChange];

--- a/Sources/CocoaLumberjack/include/CocoaLumberjack/DDFileLogger.h
+++ b/Sources/CocoaLumberjack/include/CocoaLumberjack/DDFileLogger.h
@@ -141,7 +141,7 @@ extern unsigned long long const kDDDefaultLogFilesDiskQuota;
  **/
 @property (nonatomic, readonly, strong) NSArray<DDLogFileInfo *> *sortedLogFileInfos;
 
-/// 最多允许保存几个 zip 文件. min = 1 , max = 5
+/// 最多允许保存几个 zip 文件. min = 1 , max = 100
 @property (nonatomic, readwrite, assign) NSUInteger maximumNumberOfLogZipFiles;
 
 // Private methods (only to be used by DDFileLogger)


### PR DESCRIPTION
[feat: 限制 log 日志压缩文件数量最大为 100](https://github.com/Creolophus/CocoaLumberjack/commit/6a0ad2dc4a7bde58996d20f5055474dfdc720754)
![image](https://user-images.githubusercontent.com/15530810/226266073-40de7bff-a8f7-44ee-b92f-6bd189bafd73.png)
![image](https://user-images.githubusercontent.com/15530810/226266147-b3188e3d-eec2-434e-a492-1bf52282937f.png)
